### PR TITLE
Update build and package scripts for RQD: fix import paths and version bump to 1.4.12

### DIFF
--- a/rqd/package.py
+++ b/rqd/package.py
@@ -1,6 +1,6 @@
 name = "rqd"
 
-version = "1.4.11"
+version = "1.4.12"
 
 authors = ["Open Cue"]
 
@@ -24,4 +24,6 @@ build_command = "python3 {root}/build.py {install}"
 
 def commands():
     env.PATH.append("{root}/bin")
-    env.PYTHONPATH.prepend("{root}/lib/python3.11/site-packages")
+    env.PYTHONPATH.prepend("{root}")
+    env.PYTHONPATH.prepend("{root}/rqd/compiled_proto")
+    env.CUEBOT_HOSTNAME.set("odfarm01")


### PR DESCRIPTION
This pull request introduces significant updates to the RQD build system, transitioning from a virtual environment-based approach to a more streamlined direct compilation and installation process. The changes also include improvements to how proto files are handled and updates to configurations for better compatibility.

### Build system overhaul:
* Removed the use of `venv` for creating virtual environments and replaced it with a direct compilation approach for proto files using `grpc_tools.protoc`. This includes creating a `compiled_proto` directory, compiling `.proto` files, and running a 2to3 conversion when necessary. (`rqd/build.py`, [rqd/build.pyL28-R220](diffhunk://#diff-d30a5dee416693602cb6e6fdc4f4502c2bcaab4892a8002f48b1910bd7755680L28-R220))
* Added a new helper function `_fix_rqd_imports` to update import statements in RQD source files to use `rqd.compiled_proto` instead of `opencue_proto`. (`rqd/build.py`, [rqd/build.pyR19-R49](diffhunk://#diff-d30a5dee416693602cb6e6fdc4f4502c2bcaab4892a8002f48b1910bd7755680R19-R49))

### Configuration updates:
* Updated the package version from `1.4.11` to `1.4.12`. (`rqd/package.py`, [rqd/package.pyL3-R3](diffhunk://#diff-ebe2d85488cc9865f98195ef2ded904884dd17246eaa038b02d28e9802951e50L3-R3))
* Modified the `PYTHONPATH` environment variable to include the `compiled_proto` directory and set a new `CUEBOT_HOSTNAME` environment variable. (`rqd/package.py`, [rqd/package.pyL27-R29](diffhunk://#diff-ebe2d85488cc9865f98195ef2ded904884dd17246eaa038b02d28e9802951e50L27-R29))

### Code cleanup:
* Removed the unused `venv` import from `rqd/build.py`. (`rqd/build.py`, [rqd/build.pyL10](diffhunk://#diff-d30a5dee416693602cb6e6fdc4f4502c2bcaab4892a8002f48b1910bd7755680L10))