### PR TITLE
Update pycue dependency version to 1.4.11 in package.py

### DIFF
--- a/pyoutline/package.py
+++ b/pyoutline/package.py
@@ -12,7 +12,7 @@ build_requires = ["python-3.11", "loguru"]
 
 requires = [
     "python-3.11",
-    "pycue-1.0.0",
+    "pycue-1.4.11",
 ]
 
 tools = ["pycuerun"]


### PR DESCRIPTION
This pull request updates the dependency version in the `pyoutline/package.py` file to ensure compatibility with the latest features and bug fixes.

Dependency update:

* Updated the `pycue` dependency from version `1.0.0` to `1.4.11` in the `requires` list.
