### PR TITLE
Refactor build requirements in package.py to separate grpcio dependency

### DIFF
--- a/pycue/package.py
+++ b/pycue/package.py
@@ -8,15 +8,16 @@ description = """
     Python API for OpenCue.
     """
 
-build_requires = ["python-3.11", "grpcio_tools-1+<2", "loguru"]
+build_requires = ["python-3.11", "loguru"]
 
 requires = [
     "python-3.11",
-    "grpcio-1+<2",
     "PyYAML-6+<7",
     "six-1+<2",
     "future-1+<2",
 ]
+
+private_build_requires = ["grpcio_tools-1+<2", "grpcio-1+<2"]
 
 uuid = "repository.pycue"
 


### PR DESCRIPTION
This pull request updates the package dependencies in `pycue/package.py` to reorganize and clarify the build requirements. The most important changes include moving some dependencies from `build_requires` to a new `private_build_requires` list and ensuring consistency in dependency declarations.

Dependency updates:

* Removed `grpcio_tools-1+<2` from `build_requires` and added it to a new `private_build_requires` list to separate private build dependencies.
* Removed `grpcio-1+<2` from both `build_requires` and `requires`, and added it to `private_build_requires` for better dependency management.